### PR TITLE
add_coordinates won't update if unnecessary

### DIFF
--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -79,7 +79,9 @@ add_coordinates <- function(x,
       # If overwrite == FALSE and lon/lat columns already exist,
       # overwrite only rows with NA lon and lat
       which_rows <- !complete.cases(get_coordinates(x))
-      x$linelist[which_rows, coordinates] <- ggmap::geocode(the_locations[which_rows])
+      if (any(which_rows)) {
+        x$linelist[which_rows, coordinates] <- ggmap::geocode(the_locations[which_rows])
+      }
     } else {
       # Otherwise, get all geocodes and write them to lon/lat columns
       x$linelist[, coordinates] <- ggmap::geocode(as.character(the_locations))

--- a/tests/testthat/test_coordinates.R
+++ b/tests/testthat/test_coordinates.R
@@ -7,6 +7,15 @@ test_that("coordinates can be added, period", {
   expect_identical(get_coordinates(b), YF_coordinates)
 })
 
+test_that("coordinates won't be replaced if they already exist and none are missing", {
+  b <- add_coordinates(Brazil_epiflows, YF_coordinates[-1L])
+  c <- add_coordinates(b, overwrite = TRUE)
+  expect_identical(get_coordinates(b), get_coordinates(c))
+  expect_identical(get_coordinates(b), YF_coordinates)
+})
+
+
+
 
 
 test_that("coordinates can be added over the internet", {


### PR DESCRIPTION
This is a quick PR that prevents `add_coordinates()` from attempting to add coordinates if they all exist. It prevents a potentially confusing error from geocode.