### PR TITLE
Geocode

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: epiflows
 Title: Predicting Disease Spread from Flow Data
-Version: 0.2.0
+Version: 0.2.1
 Authors@R: c(person("Pawel", "Piatkowski", email = "pawel.piatkowski@posteo.net", role = c("aut", "cre"),
              comment = c(ORCID = "0000-0002-0822-5592")),
     person("Paula", "Moraga", email = "p.e.moraga-serrano@lancaster.ac.uk", role = "aut",

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -25,9 +25,11 @@
 #' ef <- add_coordinates(Brazil_epiflows, YF_coordinates[-1])
 #' get_coordinates(ef)
 #' get_coordinates(ef, location = "Espirito Santo") # coordinates for Espirito Santo
-#' \donttest{
+#' \dontrun{
 #'   # You can use google maps' geocode functionality if you have a decent 
 #'   # internet connection
+#'   # NOTE: you may need to authenticate with Google Maps API beforehand
+#'   # using ggmap::register_google()
 #'   ef2 <- add_coordinates(Brazil_epiflows, loc_column = "id")
 #'   ef2
 #' }

--- a/R/add_coordinates.R
+++ b/R/add_coordinates.R
@@ -25,7 +25,7 @@
 #' ef <- add_coordinates(Brazil_epiflows, YF_coordinates[-1])
 #' get_coordinates(ef)
 #' get_coordinates(ef, location = "Espirito Santo") # coordinates for Espirito Santo
-#' \dontrun{
+#' if (interactive()) {
 #'   # You can use google maps' geocode functionality if you have a decent 
 #'   # internet connection
 #'   # NOTE: you may need to authenticate with Google Maps API beforehand


### PR DESCRIPTION
Due to the use of an external geocoding service (Google Maps API, now requires a key), one of the examples for `add_coordinates()` fails.
Since CRAN's checks run even the code marked as `donttest`, I suggest that we replace it with `dontrun`.