### PR TITLE
Added github url

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,6 +42,6 @@ Suggests:
     curl,
     rmarkdown
 RoxygenNote: 7.2.3
-URL: https://www.repidemicsconsortium.org/epiflows/
+URL: https://www.repidemicsconsortium.org/epiflows/, https://github.com/reconhub/epiflows
 BugReports: https://github.com/reconhub/epiflows/issues
 VignetteBuilder: knitr


### PR DESCRIPTION
The github URL is added to the description. This will give cran users awareness of the GitHub location.

For an example see https://github.com/tidyverse/dplyr/blob/main/DESCRIPTION