### PR TITLE
update for current geosphere

### DIFF
--- a/R/as.SpatialLinesDataFrame.R
+++ b/R/as.SpatialLinesDataFrame.R
@@ -62,7 +62,7 @@ make_SpatialLinesDataFrame <- function(the_flows, the_coordinates) {
                                   n = 100L,
                                   breakAtDateLine = TRUE,
                                   addStartEnd = TRUE,
-                                  sp = TRUE
+                                  output = "sp"
   )
   # Third step: rename the lines because they get named generic numbers
   row.names(SL)        <- paste(from_coordinates$id, to_coordinates$id, sep = ":")


### PR DESCRIPTION
Please consider this minor change to reflect a change in `geosphere::gcIntermediate`. In a future version of geosphere, the current code "sp=TRUE" will not work anymore.

I would also suggest to use "sf" or "terra" spatial objects rather than the obsolete "sp" objects but I did not make that change.
